### PR TITLE
Fix error

### DIFF
--- a/extension-list@tu.berry/schemas/org.gnome.shell.extensions.extension-list.gschema.xml
+++ b/extension-list@tu.berry/schemas/org.gnome.shell.extensions.extension-list.gschema.xml
@@ -30,6 +30,10 @@
             <default>true</default>
             <summary>show pin button</summary>
         </key>
+        <key type="b" name="unpin-button">
+            <default>true</default>
+            <summary>show unpin button</summary>
+        </key>
         <key type="b" name="debug-button">
             <default>false</default>
             <summary>show debug button</summary>


### PR DESCRIPTION
I'm getting the error `GSettings key unpin-button not found in schema org.gnome.shell.extensions.extension-list` in Extensions. This is because you removed the key unpin-button. In this pull request I'm adding that key back.